### PR TITLE
Change dar to match app-name in sip.xml

### DIFF
--- a/src/main/resources/archetype-resources/dar/mobicents-dar.properties
+++ b/src/main/resources/archetype-resources/dar/mobicents-dar.properties
@@ -1,1 +1,1 @@
-INVITE: ("com.mycompany.app.HelloWorldSipApplication", "DAR:From", "TERMINATING", "", "NO_ROUTE", "0")
+INVITE: ("com.mycompany.app.HelloSipWorldApplication", "DAR:From", "TERMINATING", "", "NO_ROUTE", "0")


### PR DESCRIPTION
I had used https://github.com/RestComm/sip-servlets/wiki/SipAppArchetype, and just couldn't get it to work...

Without this change, this HelloWorld does not intercept any SIP messages and just doesn't do anything....
